### PR TITLE
Update kubernetes.tf

### DIFF
--- a/{{cookiecutter.github_repo_name}}/terraform/environments/modules/mysql/kubernetes.tf
+++ b/{{cookiecutter.github_repo_name}}/terraform/environments/modules/mysql/kubernetes.tf
@@ -155,7 +155,7 @@ resource "kubernetes_secret" "xqueue" {
   }
 }
 
-{% endif %}{% if cookiecutter.ci_deploy_install_credentials_server|upper == "Y" -%}
+{% if cookiecutter.ci_deploy_install_credentials_server|upper == "Y" -%}
 resource "random_password" "mysql_credentials" {
   length           = 16
   special          = true


### PR DESCRIPTION
Remove wrong endif in template

### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [X] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- Fixes an issue causing
```
jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'endif'.
  File "terraform/environments/modules/mysql/kubernetes.tf", line 158
    {% endif %}{% if cookiecutter.ci_deploy_install_credentials_server|upper == "Y" -%}
```

### Describe Changes
Removed wrong endif tag in mysql/kubernetes.tf